### PR TITLE
Set form autocomplete off

### DIFF
--- a/template.html
+++ b/template.html
@@ -49,7 +49,7 @@ img.logo {
 <body>
 <div class="main">
   <img class="logo" src="https://lh3.googleusercontent.com/HPc5gptPzRw3wFhJE1ZCnTqlvEvuVFBAsV9etfouOhdRbkp-zNtYTzKUmUVPERSZ_lAL=w300"><br/>
-  <form method="POST">
+  <form method="POST" autocomplete="off">
     <input type="text" id="token" name="p" placeholder="Authentication Token"><br/>
     <input type="submit" value="Submit">
   </form>


### PR DESCRIPTION
Prevents browsers needlessly caching old TOTP codes