### PR TITLE
Move to using onetimepass.valid_totp()

### DIFF
--- a/auth
+++ b/auth
@@ -58,8 +58,7 @@ if user is None or user_secret is None:
     print("Contact your administrator to obtain your 2FA secret.\n")
     sys.exit()
 
-token_gen = str(onetimepass.get_totp(user_secret))
-if token_user == token_gen:
+if onetimepass.valid_totp(token=token_user, secret=user_secret, window=1):
     cookie = Cookie.SimpleCookie()
     # Create a random key and store it in session cookie
     random = os.urandom(80)


### PR DESCRIPTION
This code should use onetimepass.valid_totp() which can also allow for the situations where the OTP time period "rolls over" as the user is typing the OTP in. How many OTPs before and after the current one to allow is controlled by the windows=N parameter.